### PR TITLE
Restore Engineering Belts to Lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -102,6 +102,7 @@
       - id: LunchboxEngineeringFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
       - id: AccessConfigurator
+      - id: ClothingBeltUtilityAtmos # Floofstation
 
 - type: entity
   id: LockerAtmosphericsFilled
@@ -124,6 +125,7 @@
       - id: LunchboxEngineeringFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
       - id: AccessConfigurator
+      - id: ClothingBeltUtilityAtmos # Floofstation
 
 - type: entity
   id: LockerEngineerFilledHardsuit
@@ -141,6 +143,7 @@
       - id: LunchboxEngineeringFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
       - id: AccessConfigurator
+      - id: ClothingBeltUtilityEngineering # Floofstation
 
 - type: entity
   id: LockerEngineerFilled
@@ -157,6 +160,7 @@
       - id: LunchboxEngineeringFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
       - id: AccessConfigurator
+      - id: ClothingBeltUtilityEngineering # Floofstation
 
 - type: entity
   id: ClosetRadiationSuitFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -137,6 +137,7 @@
     contents:
       - id: ClothingOuterHardsuitEngineeringWhite
       - id: ClothingLongcoatCE # Floofstation
+      - id: ClothingBeltChiefEngineerFilled # Floofstation
       - id: ClothingMaskBreath
       - id: ClothingEyesGlassesMeson
       - id: ClothingShoesBootsMagAdv


### PR DESCRIPTION

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Adds the CE belt back to the CE hardsuit locker as requested. Also added the engineering belts to their lockers, as requested. This is a port/cherry-pick of my Floofstation PR https://github.com/Fansana/floofstation1/pull/695.


---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Cherry-pick https://github.com/Fansana/floofstation1/pull/695

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Returned the lost engineering belts to their rightful place in the engineering lockers.
