### PR TITLE
Epistemics name change and speech_emotes line removal

### DIFF
--- a/Resources/Locale/en-US/deltav/job/department.ftl
+++ b/Resources/Locale/en-US/deltav/job/department.ftl
@@ -1,4 +1,4 @@
-department-Epistemics = Epistemics
+department-Epistemics = Research and Development
 department-Logistics = Logistics
 department-Justice = Justice
 

--- a/Resources/Locale/en-US/deltav/job/job-names.ftl
+++ b/Resources/Locale/en-US/deltav/job/job-names.ftl
@@ -5,3 +5,4 @@ job-name-prosecutor = Prosecutor
 job-name-lawyer = Attorney
 job-name-courier = Courier
 job-name-admin-assistant = Administrative Assistant
+job-name-mystagogue = Research Director

--- a/Resources/Prototypes/Nyanotrasen/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Nyanotrasen/Voice/speech_emotes.yml
@@ -10,7 +10,6 @@
     - HarpyEmotes
     - ShadowkinEmotes
     - UnathiEmotes
-    - ChitinidEmotes # Floof - M3739 - #726
   blacklist:
     tags:
       - SiliconEmotes


### PR DESCRIPTION


# Description

Changes the Epistemics department name to "Research and Development." Chitinid hiss has been removed from speech_emotes.yml for the meantime.

---

# TODO


- [x] Rename Epistemics to Research and Development
- [x] Remove chitinid hiss from speech_emotes.yml temporarily
- [x] Rename Mystagogue to Research Director

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it


# Changelog



:cl:
-changed Epistemics to Research and Development
-Renamed Mystagogue to Research Director
-removed Chitinid Hiss from speech_emotes.yml
