### PR TITLE
Fix unpickable markings

### DIFF
--- a/Resources/Prototypes/DeltaV/Species/chitinid.yml
+++ b/Resources/Prototypes/DeltaV/Species/chitinid.yml
@@ -88,6 +88,11 @@
     RightArm:
       points: 6
       required: false
+    # Foxtrot start
+    Overlay:
+      points: 1
+      required: false
+    # Foxtrot end
 
 - type: humanoidBaseSprite
   id: MobChitinidHead

--- a/Resources/Prototypes/DeltaV/Species/kitsune.yml
+++ b/Resources/Prototypes/DeltaV/Species/kitsune.yml
@@ -46,3 +46,50 @@
     # Arms:
       # points: 2
       # required: false
+    # Foxtrot start
+    Face:
+      points: 1
+      required: false
+    Head:
+      points: 1
+      required: false
+    HeadSide:
+      points: 1
+      required: false
+    RightArm:
+      points: 1
+      required: false
+    RightHand:
+      points: 1
+      required: false
+    LeftArm:
+      points: 1
+      required: false
+    LeftHand:
+      points: 1
+      required: false
+    RightLeg:
+      points: 1
+      required: false
+    RightFoot:
+      points: 1
+      required: false
+    LeftLeg:
+      points: 1
+      required: false
+    LeftFoot:
+      points: 1
+      required: false
+    Genitals:
+      points: 1
+      required: false
+    Underwear:
+      points: 1
+      required: false
+    Undershirt:
+      points: 1
+      required: false
+    Overlay:
+      points: 1
+      required: false
+    # Foxtrot end

--- a/Resources/Prototypes/DeltaV/Species/rodentia.yml
+++ b/Resources/Prototypes/DeltaV/Species/rodentia.yml
@@ -108,6 +108,11 @@
     Undershirt:
       points: 1
       required: false
+    # Foxtrot start
+    Overlay:
+      points: 1
+      required: false
+    # Foxtrot end
 
 - type: humanoidBaseSprite
   id: MobRodentiaHead

--- a/Resources/Prototypes/DeltaV/Species/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Species/vulpkanin.yml
@@ -96,6 +96,20 @@
     HeadSide:
       points: 6
       required: false
+    # Foxtrot start
+    Face:
+      points: 1
+      required: false
+    Head:
+      points: 1
+      required: false
+    Chest:
+      points: 1
+      required: false
+    Overlay:
+      points: 1
+      required: false
+    # Foxtrot end
 
 - type: humanoidBaseSprite
   id: MobVulpkaninHead

--- a/Resources/Prototypes/Nyanotrasen/Entities/Body/Prototypes/oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Body/Prototypes/oni.yml
@@ -79,3 +79,17 @@
     Undershirt:
       points: 1
       required: false
+    # Foxtrot start
+    Face:
+      points: 1
+      required: false
+    Head:
+      points: 1
+      required: false
+    Tail:
+      points: 1
+      required: false
+    Overlay:
+      points: 1
+      required: false
+    # Foxtrot end

--- a/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
@@ -72,3 +72,20 @@
     Undershirt:
       points: 1
       required: false
+    # Foxtrot start
+    Face:
+      points: 1
+      required: false
+    Head:
+      points: 1
+      required: false
+    HeadSide:
+      points: 1 # Is this one needed?
+      required: false
+    Snout:
+      points: 1
+      required: false
+    Overlay:
+      points: 1
+      required: false
+    # Foxtrot end

--- a/Resources/Prototypes/Species/arachne.yml
+++ b/Resources/Prototypes/Species/arachne.yml
@@ -53,6 +53,20 @@
     LeftHand:
       points: 6
       required: false
+    # Foxtrot start
+    Face:
+      points: 1
+      required: false
+    Head:
+      points: 1
+      required: false
+    Snout:
+      points: 1
+      required: false
+    Overlay:
+      points: 1
+      required: false
+    # Foxtrot end
 
 
 - type: speciesBaseSprites

--- a/Resources/Prototypes/Species/arachnid.yml
+++ b/Resources/Prototypes/Species/arachnid.yml
@@ -96,6 +96,17 @@
     LeftHand:
       points: 6
       required: false
+    # Foxtrot start
+    Overlay:
+      points: 1
+      required: false
+    Head:
+      points: 1
+      required: false
+    Genitals:
+      points: 1 # do these work?
+      required: false
+    # Foxtrot end
 
 - type: humanoidBaseSprite
   id: MobArachnidHead

--- a/Resources/Prototypes/Species/harpy.yml
+++ b/Resources/Prototypes/Species/harpy.yml
@@ -96,6 +96,20 @@
     LeftHand:
       points: 2
       required: false
+    # Foxtrot start
+    Face:
+      points: 1
+      required: false
+    Head:
+      points: 1
+      required: false
+    Snout:
+      points: 1
+      required: false
+    Overlay:
+      points: 1
+      required: false
+    # Foxtrot end
 
 - type: humanoidBaseSprite
   id: MobHarpyHead

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -100,6 +100,17 @@
     LeftHand:
       points: 6
       required: false
+    # Foxtrot start
+    Face:
+      points: 1
+      required: false
+    Head:
+      points: 1
+      required: false
+    Overlay:
+      points: 1
+      required: false
+    # Foxtrot end
 
 - type: humanoidBaseSprite
   id: MobHumanoidEyes

--- a/Resources/Prototypes/Species/ipc.yml
+++ b/Resources/Prototypes/Species/ipc.yml
@@ -108,6 +108,17 @@
     Wings:
       points: 1
       required: false
+    # Foxtrot start
+    Overlay:
+      points: 1
+      required: false
+    Tail:
+      points: 1
+      required: false
+    HeadTop:
+      points: 1
+      required: false
+    # Foxtrot end
 
 - type: humanoidBaseSprite
   id: MobIPCMarkingFollowSkin

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -101,6 +101,14 @@
     LeftHand:
       points: 6
       required: false
+    # Foxtrot start
+    Face:
+      points: 1
+      required: false
+    Overlay:
+      points: 1
+      required: false
+    # Foxtrot end
 
 - type: humanoidBaseSprite
   id: MobMothHead

--- a/Resources/Prototypes/Species/plasmaman.yml
+++ b/Resources/Prototypes/Species/plasmaman.yml
@@ -81,6 +81,20 @@
     LeftHand:
       points: 2
       required: false
+    # Foxtrot start
+    Head:
+      points: 1
+      required: false
+    Wings:
+      points: 1
+      required: false
+    Underwear:
+      points: 1
+      required: false
+    Undershirt:
+      points: 1
+      required: false
+    # Foxtrot end
 
 - type: humanoidBaseSprite
   id: MobPlasmamanHead

--- a/Resources/Prototypes/Species/reptilian.yml
+++ b/Resources/Prototypes/Species/reptilian.yml
@@ -100,6 +100,17 @@
     LeftHand:
       points: 6
       required: false
+    # Foxtrot start
+    Face:
+      points: 1
+      required: false
+    Head:
+      points: 1
+      required: false
+    Overlay:
+      points: 1
+      required: false
+    # Foxtrot end
 
 - type: humanoidBaseSprite
   id: MobReptilianHead

--- a/Resources/Prototypes/Species/shadowkin.yml
+++ b/Resources/Prototypes/Species/shadowkin.yml
@@ -97,6 +97,11 @@
     LeftHand:
       points: 6
       required: false
+    # Foxtrot start
+    Overlay:
+      points: 1
+      required: false
+    # Foxtrot end
 
 - type: humanoidBaseSprite
   id: MobShadowkinAnyMarkingFollowSkin

--- a/Resources/Prototypes/Species/slime.yml
+++ b/Resources/Prototypes/Species/slime.yml
@@ -101,6 +101,14 @@
     LeftHand:
       points: 6
       required: false
+    # Foxtrot start
+    Face:
+      points: 1
+      required: false
+    Overlay:
+      points: 1
+      required: false
+    # Foxtrot end
 
 - type: humanoidBaseSprite
   id: MobSlimeMarkingFollowSkin

--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -93,6 +93,20 @@
       points: 1
       required: true
       defaultMarkings: [ VoxTail ]
+    # Foxtrot start
+    HeadSide:
+      points: 1
+      required: false
+    Genitals:
+      points: 1
+      required: false
+    Underwear:
+      points: 1
+      required: false
+    Undershirt:
+      points: 1
+      required: false
+    # Foxtrot end
 
 - type: humanoidBaseSprite
   id: MobVoxEyes

--- a/Resources/Prototypes/_ADT/Mobs/Customization/custom/Human_tattoos.yml
+++ b/Resources/Prototypes/_ADT/Mobs/Customization/custom/Human_tattoos.yml
@@ -137,7 +137,7 @@
   id: HumanTattooSkeletfootL
   bodyPart: LFoot
   markingCategory: LeftFoot
-  speciesRestriction: [Human, Oni, Reptilian, SlimePerson, Arachnid, Tajaran, Felinid, Arachne, Shadowkin, Moth, Vulpkanin]
+  speciesRestriction: [Human, Oni, Reptilian, SlimePerson, Arachnid, Tajaran, Felinid, Shadowkin, Moth, Vulpkanin] # Foxtrot - removed Arachne
   sprites:
   - sprite: _ADT/Mobs/Customization/Human/custom.rsi
     state: tattoo_skelet_foot_l
@@ -146,7 +146,7 @@
   id: HumanTattooSkeletfootR
   bodyPart: RFoot
   markingCategory: RightFoot
-  speciesRestriction: [Human, Oni, Reptilian, SlimePerson, Arachnid, Tajaran, Felinid, Arachne, Shadowkin, Moth, Vulpkanin]
+  speciesRestriction: [Human, Oni, Reptilian, SlimePerson, Arachnid, Tajaran, Felinid, Shadowkin, Moth, Vulpkanin] # Foxtrot - removed Arachne
   sprites:
   - sprite: _ADT/Mobs/Customization/Human/custom.rsi
     state: tattoo_skelet_foot_r
@@ -155,7 +155,7 @@
   id: HumanTattooSkeletlegL
   bodyPart: LLeg
   markingCategory: LeftLeg
-  speciesRestriction: [Human, Oni, Reptilian, SlimePerson, Arachnid, Tajaran, Felinid, Arachne, Shadowkin, Moth, Vulpkanin]
+  speciesRestriction: [Human, Oni, Reptilian, SlimePerson, Arachnid, Tajaran, Felinid, Shadowkin, Moth, Vulpkanin] # Foxtrot - removed Arachne
   sprites:
   - sprite: _ADT/Mobs/Customization/Human/custom.rsi
     state: tattoo_skelet_leg_l
@@ -164,7 +164,7 @@
   id: HumanTattooSkeletlegR
   bodyPart: RLeg
   markingCategory: RightLeg
-  speciesRestriction: [Human, Oni, Reptilian, SlimePerson, Arachnid, Tajaran, Felinid, Arachne, Shadowkin, Moth, Vulpkanin]
+  speciesRestriction: [Human, Oni, Reptilian, SlimePerson, Arachnid, Tajaran, Felinid, Shadowkin, Moth, Vulpkanin] # Foxtrot - removed Arachne
   sprites:
   - sprite: _ADT/Mobs/Customization/Human/custom.rsi
     state: tattoo_skelet_leg_r

--- a/Resources/Prototypes/_DEN/Species/canid.yml
+++ b/Resources/Prototypes/_DEN/Species/canid.yml
@@ -75,3 +75,20 @@
     Undershirt:
       points: 1
       required: false
+    # Foxtrot start
+    Face:
+      points: 1
+      required: false
+    Head:
+      points: 1
+      required: false
+    HeadSide:
+      points: 1
+      required: false
+    Snout:
+      points: 1
+      required: false
+    Overlay:
+      points: 1
+      required: false
+    # Foxtrot end

--- a/Resources/Prototypes/_DV/Species/feroxi.yml
+++ b/Resources/Prototypes/_DV/Species/feroxi.yml
@@ -74,6 +74,26 @@
       points: 1
       required: true
       defaultMarkings: [ FeroxiTailAndDorsal ]
+    # Foxtrot start
+    HeadSide:
+      points: 1
+      required: false
+    Genitals:
+      points: 1
+      required: false
+    Nipples:
+      points: 1
+      required: false
+    Underwear:
+      points: 1
+      required: false
+    Undershirt:
+      points: 1
+      required: false
+    Overlay:
+      points: 1
+      required: false
+    # Foxtrot end
 
 - type: humanoidBaseSprite
   id: MobFeroxiHead

--- a/Resources/Prototypes/_EE/Species/tajaran.yml
+++ b/Resources/Prototypes/_EE/Species/tajaran.yml
@@ -75,6 +75,17 @@
     LeftHand:
       points: 6
       required: false
+    # Foxtrot start
+    Face:
+      points: 1
+      required: false
+    Head:
+      points: 1
+      required: false
+    Overlay:
+      points: 1
+      required: false
+    # Foxtrot end
 
 - type: speciesBaseSprites
   id: MobTajaranSprites


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

The new markings UI appears to have changed the default behavior from unlimited to confusing for the player. This change seems to be intentional, with several baked-in checks for -1 (the default if not defined).

To remedy this, I started adding defined marking points for all of the reported categories that were missing. There are almost certainly more to do, and so far I was only giving categories one point. This should likely be changed.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Define reported broken marking categories
- [x] Define remaining marking categories (whatever they may be)
- [ ] (optional?)Put better point values

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added fun :D
- tweak: Tweaked fun
- fix: Fixed fun!
- remove: Removed fun :(
