### PR TITLE
Adds the Station AI role to Asterisk and Edge

### DIFF
--- a/Resources/Prototypes/Maps/asterisk.yml
+++ b/Resources/Prototypes/Maps/asterisk.yml
@@ -76,3 +76,5 @@
             CargoTechnician: [ 2, 4 ]
           #civilian
             Passenger: [ -1, -1 ]
+          #silicon
+            StationAi: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/edge.yml
+++ b/Resources/Prototypes/Maps/edge.yml
@@ -74,3 +74,5 @@
             CargoTechnician: [ 2, 4 ]
           #civilian
             Passenger: [ -1, -1 ]
+          #silicon
+            StationAi: [ 1, 1 ]


### PR DESCRIPTION


# Description

Asterisk and Edge has no AI role, even though there is an AI mapped in each, this commit changes this so there is the AI role players can join as AI on those stations

Multiple times i've wanted to play as AI but when joining i've noticed the role was missing in the late join list, even though the AI is fully mapped and prepared on the station.

As for balance, a Station AI allows the Micropop of Foxtrot a lot more visibility and awareness, making Survival a much more plausible option as the Station AI can help find any anomaly that spawns or lock Xenos into rooms so that they are not as large of a threat. As such they do majorly impact balance on the maps where they are present, however as they were fully mapped I presume this is Intentional.


---

# TODO

[X] Create fork off Foxtrot
[X] Create branch on my fork 
[X] Create development environment on the branch for foxtrot
[X] Find the ID for Station AI
[X] Check Edge - Has AI onstation - No Role
[X] Check Asterisk - Has AI onstation - No Role
[X] Check Shoko - Has AI onstation - Rolled - No Action
[X] Check Pebble - Has AI onstation - Rolled - No Action
[X]  Add the Station AI to Foxtrot/Resources/Prototypes/Maps/edge.yml
[X]  Add the Station AI to Foxtrot/Resources/Prototypes/Maps/asterisk.yml
[X] Test all maps
[X] Create PR 
---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->
![sdfgagchvdsadghj](https://github.com/user-attachments/assets/8cbb2831-cb8a-47be-a0ca-fd38c57d903d)
![jhgfdsafghdsa](https://github.com/user-attachments/assets/4052c29d-2d6b-4078-8acf-40af2a004c68)


---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added AI Role to Asterisk and Edge
