### PR TITLE
Restricted Equipment Trait + IPC Traits Cleanup

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -617,38 +617,6 @@ trait-description-BionicLeg =
     One or more of your limbs have been replaced with an expensive, state of the art bionic. It could be either one made of highly realistic synthflesh,
     or a more obvious metal limb. This limb provides enhanced speed to it's user, allowing you to run away from situations faster or get to a place faster.
 
-trait-name-FlareShieldingModule = I.P.C Eye Module: Flare Shielding
-trait-description-FlareShieldingModule =
-   Your eyes have been fitted with a photochromic lens that automatically darkens in response to intense stimuli.
-   This provides immunity from most bright flashes of light, such as those from welding arcs.
-
-trait-name-SecurityEyesModule = I.P.C Eye Module: Sechud
-trait-description-SecurityEyesModule =
-    A module installed in IPCs that work for the security department and similar, this module is considered contraband and may be removed if the unit isn't working for the security department.
-
-trait-name-MedicalEyesModule = I.P.C Eye Module: Medical
-trait-description-MedicalEyesModule =
-    Your eyes have been upgraded to include a built-in Medical Hud, and a Chemical Analysis Hud, allowing you to track the relative health condition of biological organisms, and discern the chemicals in any solution.
-
-trait-name-DiagnosticEyesModule = I.P.C Eye Module: Diagnostics
-trait-description-DiagnosticEyesModule =
-    Your eyes have been upgraded to include a built-in Diagnostic Hud and flare shielding, allowing you to track the condition of synthetic entities, and providing eye protection against welding arcs.
-
-trait-name-OmniEyesModule = I.P.C Eye Module: Premium Model
-trait-description-OmniEyesModule =
-    This upgrade provides the combined benefits of a SecHud, MedHud, and a Diagnostics Module.
-    Note that this module is considered Contraband for anyone not under the employ of station Security personel,
-    and may be disabled by your employer before dispatch to the station.
-
-trait-name-LightAmplificationModule = I.P.C Eye Module: Light Amplification
-trait-description-LightAmplificationModule =
-    Your vision has been enhanced with a light amplifier module, enabling the user to toggle between standard sight and "Night Vision" mode.
-
-trait-name-ThermographicVisionModule = I.P.C Eye Module: Thermographic Scanner
-trait-description-ThermographicVisionModule =
-    Your vision has been enhanced with a Thermographic Scanner. When enabled, it captures a snapshot of the user's surroundings, while highlighting all
-    biological life forms. It can even detect individuals through the walls of a station.
-
 trait-name-Vampirism = Vampirism
 trait-description-Vampirism =
     Your body has evolved to be able to suck blood from beings that contain it and metabolize it into useful compounds.
@@ -678,3 +646,9 @@ trait-name-Bodybuilder = Bodybuilder
 trait-description-Bodybuilder =
     Through extensive training or body modification, you have achieved the pinnacle of physique.
     This trait halves the movement speed penalty when dragging something.
+
+trait-name-RestrictedGear = Restricted Gear
+trait-description-RestrictedGear = 
+    Either through personal ownership or theft, you have access to equipment that isn't particularly standard issue.
+    Note that starting with an item [color=red]doesn't certify its legality[/color]. Conceal it or justify it.
+    (You equip other jobs' items and traits in the loadouts and traits menu) 

--- a/Resources/Prototypes/Loadouts/Jobs/Command/traitRestrictedGear.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/traitRestrictedGear.yml
@@ -1,0 +1,90 @@
+### All Security
+## Holster
+- type: loadout
+  id: LoadoutSecurityRestrictedGearBeltHolster
+  category: JobsSecurityAUncategorized
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Security
+  items:
+    - ClothingBeltHolster
+
+## Outer
+- type: loadout
+  id: LoadoutSecurityRestrictedGearOuterArmorPlateCarrier
+  category: JobsSecurityAUncategorized
+  cost: 7
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSecurityOuter
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Security
+  items:
+    - ClothingOuterArmorPlateCarrier
+
+- type: loadout
+  id: LoadoutSecurityRestrictedGearOuterArmorDuraVest
+  category: JobsSecurityAUncategorized
+  cost: 7
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSecurityOuter
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Security
+  items:
+    - ClothingOuterArmorDuraVest
+
+- type: loadout
+  id: LoadoutSecurityRestrictedGearOuterArmorBasic
+  category: JobsSecurityAUncategorized
+  cost: 7
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSecurityOuter
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Security
+  items:
+    - ClothingOuterArmorBasic
+
+- type: loadout
+  id: LoadoutSecurityRestrictedGearOuterArmorSlim
+  category: JobsSecurityAUncategorized
+  cost: 7
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSecurityOuter
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Security
+  items:
+    - ClothingOuterArmorBasicSlim

--- a/Resources/Prototypes/Loadouts/Jobs/Command/traitRestrictedGear.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/traitRestrictedGear.yml
@@ -1,90 +1,25 @@
-### All Security
-## Holster
+### All Command
+## Misc
 - type: loadout
-  id: LoadoutSecurityRestrictedGearBeltHolster
-  category: JobsSecurityAUncategorized
-  cost: 2
+  id: LoadoutCommandRestrictedGearPenCentcom
+  category: JobsCommandAUncategorized
+  cost: 5
   exclusive: true
   requirements:
     - !type:CharacterTraitRequirement
       traits:
         - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Security
   items:
-    - ClothingBeltHolster
-
-## Outer
+    - PenCentcom
+    
 - type: loadout
-  id: LoadoutSecurityRestrictedGearOuterArmorPlateCarrier
-  category: JobsSecurityAUncategorized
-  cost: 7
+  id: LoadoutCommandRestrictedGearCyberPen
+  category: JobsCommandAUncategorized
+  cost: 5
   exclusive: true
   requirements:
     - !type:CharacterTraitRequirement
       traits:
         - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSecurityOuter
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Security
   items:
-    - ClothingOuterArmorPlateCarrier
-
-- type: loadout
-  id: LoadoutSecurityRestrictedGearOuterArmorDuraVest
-  category: JobsSecurityAUncategorized
-  cost: 7
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSecurityOuter
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Security
-  items:
-    - ClothingOuterArmorDuraVest
-
-- type: loadout
-  id: LoadoutSecurityRestrictedGearOuterArmorBasic
-  category: JobsSecurityAUncategorized
-  cost: 7
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSecurityOuter
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Security
-  items:
-    - ClothingOuterArmorBasic
-
-- type: loadout
-  id: LoadoutSecurityRestrictedGearOuterArmorSlim
-  category: JobsSecurityAUncategorized
-  cost: 7
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSecurityOuter
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Security
-  items:
-    - ClothingOuterArmorBasicSlim
+    - CyberPen

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/traitRestrictedGear.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/traitRestrictedGear.yml
@@ -1,0 +1,220 @@
+### All Engineers
+## Mesons
+- type: loadout
+  id: LoadoutEngineeringRestrictedGearEyesMeson
+  category: JobsEngineeringAAUncategorized
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutEyesEngineering
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Engineering
+  items:
+    - ClothingEyesGlassesMeson
+
+## Tools
+# Wirecutter
+- type: loadout
+  id: LoadoutEngineeringRestrictedGearEquipmentWirecutter
+  category: JobsEngineeringAAUncategorized
+  cost: 1
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Engineering
+  items:
+    - Wirecutter
+
+# Screwdriver
+- type: loadout
+  id: LoadoutEngineeringRestrictedGearEquipmentScrewdriver
+  category: JobsEngineeringAAUncategorized
+  cost: 1
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Engineering
+  items:
+    - Screwdriver
+
+# Wrench
+- type: loadout
+  id: LoadoutEngineeringRestrictedGearEquipmentWrench
+  category: JobsEngineeringAAUncategorized
+  cost: 1
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Engineering
+  items:
+    - Wrench
+
+# White Crowbar
+- type: loadout
+  id: LoadoutEngineeringRestrictedGearEquipmentCrowbar
+  category: JobsEngineeringAAUncategorized
+  cost: 1
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Engineering
+  items:
+    - Crowbar
+
+# Multitool
+- type: loadout
+  id: LoadoutEngineeringRestrictedGearEquipmentMultitool
+  category: JobsEngineeringAAUncategorized
+  cost: 2
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Engineering
+  items:
+    - Multitool
+
+# Power Drill
+- type: loadout
+  id: LoadoutEngineeringRestrictedGearPowerDrill
+  category: JobsEngineeringAAUncategorized
+  cost: 3
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Engineering
+  items:
+    - PowerDrill
+
+## Insulated Gloves Variations
+# Yellow
+- type: loadout
+  id: LoadoutEngineeringRestrictedGearGlovesInsulated
+  category: JobsEngineeringAAUncategorized
+  cost: 3
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutEngineeringGloves
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Engineering
+  items:
+    - ClothingHandsGlovesColorYellow
+
+# Black
+- type: loadout
+  id: LoadoutEngineeringRestrictedGearGlovesCombat
+  category: JobsEngineeringAAUncategorized
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutEngineeringGloves
+    # not inverted for engineers because loadout may be removed in pr 2105
+  items:
+    - ClothingHandsGlovesCombat
+
+# Merc
+- type: loadout
+  id: LoadoutEngineeringRestrictedGearGlovesMerc
+  category: JobsEngineeringAAUncategorized
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutEngineeringGloves
+    # not inverted for engineers because loadout may be removed in pr 2105
+  items:
+    - ClothingHandsMercGlovesCombat
+
+
+### Atmos
+## Utility belt
+- type: loadout
+  id: LoadoutEngineeringRestrictedGearBeltUtilityAtmos
+  category: JobsEngineeringAtmosphericTechnician
+  cost: 5
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - AtmosphericTechnician
+  items:
+    - ClothingBeltUtilityAtmos
+
+- type: loadout
+  id: LoadoutEngineeringRestrictedGearEquipmentHolofanProjector
+  category: JobsEngineeringAtmosphericTechnician
+  cost: 2
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - AtmosphericTechnician
+  items:
+    - HolofanProjector
+
+### SE
+## Utility belt
+- type: loadout
+  id: LoadoutEngineeringRestrictedGearBeltUtilityEngineering
+  category: JobsEngineeringStationEngineer
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - StationEngineer
+  items:
+    - ClothingBeltUtilityEngineering

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/traitRestrictedGear.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/traitRestrictedGear.yml
@@ -9,8 +9,6 @@
     - !type:CharacterTraitRequirement
       traits:
         - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutEyesEngineering
     - !type:CharacterDepartmentRequirement
       inverted: true
       departments:

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/traitRestrictedGear.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/traitRestrictedGear.yml
@@ -19,86 +19,6 @@
     - ClothingEyesGlassesMeson
 
 ## Tools
-# Wirecutter
-- type: loadout
-  id: LoadoutEngineeringRestrictedGearEquipmentWirecutter
-  category: JobsEngineeringAAUncategorized
-  cost: 1
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Engineering
-  items:
-    - Wirecutter
-
-# Screwdriver
-- type: loadout
-  id: LoadoutEngineeringRestrictedGearEquipmentScrewdriver
-  category: JobsEngineeringAAUncategorized
-  cost: 1
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Engineering
-  items:
-    - Screwdriver
-
-# Wrench
-- type: loadout
-  id: LoadoutEngineeringRestrictedGearEquipmentWrench
-  category: JobsEngineeringAAUncategorized
-  cost: 1
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Engineering
-  items:
-    - Wrench
-
-# White Crowbar
-- type: loadout
-  id: LoadoutEngineeringRestrictedGearEquipmentCrowbar
-  category: JobsEngineeringAAUncategorized
-  cost: 1
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Engineering
-  items:
-    - Crowbar
-
-# Multitool
-- type: loadout
-  id: LoadoutEngineeringRestrictedGearEquipmentMultitool
-  category: JobsEngineeringAAUncategorized
-  cost: 2
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Engineering
-  items:
-    - Multitool
-
 # Power Drill
 - type: loadout
   id: LoadoutEngineeringRestrictedGearPowerDrill
@@ -139,7 +59,7 @@
 - type: loadout
   id: LoadoutEngineeringRestrictedGearGlovesCombat
   category: JobsEngineeringAAUncategorized
-  cost: 4
+  cost: 3
   exclusive: true
   requirements:
     - !type:CharacterTraitRequirement
@@ -155,7 +75,7 @@
 - type: loadout
   id: LoadoutEngineeringRestrictedGearGlovesMerc
   category: JobsEngineeringAAUncategorized
-  cost: 4
+  cost: 3
   exclusive: true
   requirements:
     - !type:CharacterTraitRequirement

--- a/Resources/Prototypes/Loadouts/Jobs/Logistics/traitRestrictedGear.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Logistics/traitRestrictedGear.yml
@@ -1,0 +1,293 @@
+### Salvage Specialist
+## Belts
+# Merc webbing
+- type: loadout
+  id: LoadoutCargoRestrictedGearBeltMercWebbing
+  category: JobsLogisticsSalvageSpecialist
+  cost: 5
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistBelt
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - SalvageSpecialist
+  items:
+    - ClothingBeltMercWebbing
+
+# Salvage rig
+- type: loadout
+  id: LoadoutCargoRestrictedGearBeltSalvageWebbing
+  category: JobsLogisticsSalvageSpecialist
+  cost: 5
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistBelt
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - SalvageSpecialist
+  items:
+    - ClothingBeltSalvageWebbing
+
+# Chest rig
+- type: loadout
+  id: LoadoutCargoRestrictedGearBeltMilitaryWebbing
+  category: JobsLogisticsSalvageSpecialist
+  cost: 5
+  exclusive: true
+  customColorTint: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistBelt
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - SalvageSpecialist
+  items:
+    - ClothingBeltMilitaryWebbing
+
+
+## Weapons
+- type: loadout
+  id: LoadoutCargoRestrictedGearWeaponsCrusherDagger
+  category: JobsLogisticsSalvageSpecialist
+  cost: 5
+  canBeHeirloom: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:OverallTimeRequirement
+      min: 72000 # 20 hours
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - SalvageSpecialist
+  items:
+    - WeaponCrusherDagger
+
+- type: loadout
+  id: LoadoutCargoRestrictedGearWeaponsCombatKnife
+  category: JobsLogisticsSalvageSpecialist
+  cost: 4
+  canBeHeirloom: true
+  customColorTint: true # Go read Neuromancer
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:OverallTimeRequirement
+      min: 72000 # 20 hours
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - SalvageSpecialist
+  items:
+    - CombatKnife
+
+- type: loadout
+  id: LoadoutCargoRestrictedGearWeaponsKitchenKnife
+  category: JobsLogisticsSalvageSpecialist
+  cost: 4
+  canBeHeirloom: true
+  customColorTint: true # Go read Neuromancer
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:OverallTimeRequirement
+      min: 72000 # 20 hours
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - SalvageSpecialist
+  items:
+    - KitchenKnife
+
+- type: loadout
+  id: LoadoutCargoRestrictedGearWeaponsSurvivalKnife
+  category: JobsLogisticsSalvageSpecialist
+  cost: 4
+  canBeHeirloom: true
+  customColorTint: true # Go read Neuromancer
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:OverallTimeRequirement
+      min: 72000 # 20 hours
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - SalvageSpecialist
+  items:
+    - SurvivalKnife
+
+- type: loadout
+  id: LoadoutCargoRestrictedGearWeaponsKukriKnife
+  category: JobsLogisticsSalvageSpecialist
+  cost: 4
+  canBeHeirloom: true
+  customColorTint: true # Go read Neuromancer
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:OverallTimeRequirement
+      min: 72000 # 20 hours
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - SalvageSpecialist
+  items:
+    - KukriKnife
+
+- type: loadout
+  id: LoadoutCargoRestrictedGearWeaponsCleaver
+  category: JobsLogisticsSalvageSpecialist
+  cost: 5
+  canBeHeirloom: true
+  customColorTint: true # Go read Neuromancer
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:OverallTimeRequirement
+      min: 72000 # 20 hours
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - SalvageSpecialist
+  items:
+    - ButchCleaver
+
+- type: loadout
+  id: LoadoutCargoRestrictedGearWeaponsThrowingKnife
+  category: JobsLogisticsSalvageSpecialist
+  cost: 3
+  canBeHeirloom: true
+  customColorTint: true # Go read Neuromancer
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:OverallTimeRequirement
+      min: 72000 # 20 hours
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - SalvageSpecialist
+  items:
+    - ThrowingKnife
+    - ThrowingKnife
+    - ThrowingKnife
+
+- type: loadout
+  id: LoadoutCargoRestrictedGearWeaponsMachete
+  category: JobsLogisticsSalvageSpecialist
+  cost: 4
+  canBeHeirloom: true
+  customColorTint: true # Go read Neuromancer
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:OverallTimeRequirement
+      min: 72000 # 20 hours
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - SalvageSpecialist
+  items:
+    - Machete
+
+- type: loadout
+  id: LoadoutCargoRestrictedGearWeaponsCutlass
+  category: JobsLogisticsSalvageSpecialist
+  cost: 5
+  canBeHeirloom: true
+  customColorTint: true # Go read Neuromancer
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:OverallTimeRequirement
+      min: 72000 # 20 hours
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - SalvageSpecialist
+  items:
+    - Cutlass
+
+- type: loadout
+  id: LoadoutCargoRestrictedGearWeaponsKatana
+  category: JobsLogisticsSalvageSpecialist
+  cost: 5
+  canBeHeirloom: true
+  customColorTint: true # Go read Neuromancer
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:OverallTimeRequirement
+      min: 72000 # 20 hours
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - SalvageSpecialist
+  items:
+    - Katana
+
+- type: loadout
+  id: LoadoutCargoRestrictedGearWeaponsWakizashi
+  category: JobsLogisticsSalvageSpecialist
+  cost: 4
+  canBeHeirloom: true
+  customColorTint: true # Go read Neuromancer
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:OverallTimeRequirement
+      min: 72000 # 20 hours
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - SalvageSpecialist
+  items:
+    - Wakizashi

--- a/Resources/Prototypes/Loadouts/Jobs/Logistics/traitRestrictedGear.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Logistics/traitRestrictedGear.yml
@@ -4,7 +4,7 @@
 - type: loadout
   id: LoadoutCargoRestrictedGearBeltMercWebbing
   category: JobsLogisticsSalvageSpecialist
-  cost: 5
+  cost: 4
   exclusive: true
   requirements:
     - !type:CharacterTraitRequirement
@@ -23,7 +23,7 @@
 - type: loadout
   id: LoadoutCargoRestrictedGearBeltSalvageWebbing
   category: JobsLogisticsSalvageSpecialist
-  cost: 5
+  cost: 4
   exclusive: true
   requirements:
     - !type:CharacterTraitRequirement
@@ -42,7 +42,7 @@
 - type: loadout
   id: LoadoutCargoRestrictedGearBeltMilitaryWebbing
   category: JobsLogisticsSalvageSpecialist
-  cost: 5
+  cost: 4
   exclusive: true
   customColorTint: true
   requirements:
@@ -63,7 +63,7 @@
 - type: loadout
   id: LoadoutCargoRestrictedGearWeaponsCrusherDagger
   category: JobsLogisticsSalvageSpecialist
-  cost: 5
+  cost: 3
   canBeHeirloom: true
   requirements:
     - !type:CharacterTraitRequirement
@@ -83,7 +83,7 @@
 - type: loadout
   id: LoadoutCargoRestrictedGearWeaponsCombatKnife
   category: JobsLogisticsSalvageSpecialist
-  cost: 4
+  cost: 3
   canBeHeirloom: true
   customColorTint: true # Go read Neuromancer
   requirements:
@@ -104,7 +104,7 @@
 - type: loadout
   id: LoadoutCargoRestrictedGearWeaponsKitchenKnife
   category: JobsLogisticsSalvageSpecialist
-  cost: 4
+  cost: 1
   canBeHeirloom: true
   customColorTint: true # Go read Neuromancer
   requirements:
@@ -125,7 +125,7 @@
 - type: loadout
   id: LoadoutCargoRestrictedGearWeaponsSurvivalKnife
   category: JobsLogisticsSalvageSpecialist
-  cost: 4
+  cost: 2
   canBeHeirloom: true
   customColorTint: true # Go read Neuromancer
   requirements:
@@ -146,7 +146,7 @@
 - type: loadout
   id: LoadoutCargoRestrictedGearWeaponsKukriKnife
   category: JobsLogisticsSalvageSpecialist
-  cost: 4
+  cost: 3
   canBeHeirloom: true
   customColorTint: true # Go read Neuromancer
   requirements:
@@ -167,7 +167,7 @@
 - type: loadout
   id: LoadoutCargoRestrictedGearWeaponsCleaver
   category: JobsLogisticsSalvageSpecialist
-  cost: 5
+  cost: 1
   canBeHeirloom: true
   customColorTint: true # Go read Neuromancer
   requirements:
@@ -188,7 +188,7 @@
 - type: loadout
   id: LoadoutCargoRestrictedGearWeaponsThrowingKnife
   category: JobsLogisticsSalvageSpecialist
-  cost: 3
+  cost: 2
   canBeHeirloom: true
   customColorTint: true # Go read Neuromancer
   requirements:
@@ -211,7 +211,7 @@
 - type: loadout
   id: LoadoutCargoRestrictedGearWeaponsMachete
   category: JobsLogisticsSalvageSpecialist
-  cost: 4
+  cost: 3
   canBeHeirloom: true
   customColorTint: true # Go read Neuromancer
   requirements:
@@ -232,7 +232,7 @@
 - type: loadout
   id: LoadoutCargoRestrictedGearWeaponsCutlass
   category: JobsLogisticsSalvageSpecialist
-  cost: 5
+  cost: 3
   canBeHeirloom: true
   customColorTint: true # Go read Neuromancer
   requirements:
@@ -253,7 +253,7 @@
 - type: loadout
   id: LoadoutCargoRestrictedGearWeaponsKatana
   category: JobsLogisticsSalvageSpecialist
-  cost: 5
+  cost: 3
   canBeHeirloom: true
   customColorTint: true # Go read Neuromancer
   requirements:
@@ -274,7 +274,7 @@
 - type: loadout
   id: LoadoutCargoRestrictedGearWeaponsWakizashi
   category: JobsLogisticsSalvageSpecialist
-  cost: 4
+  cost: 3
   canBeHeirloom: true
   customColorTint: true # Go read Neuromancer
   requirements:

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/traitRestrictedGear.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/traitRestrictedGear.yml
@@ -1,0 +1,462 @@
+### All Medical
+
+## Surgery
+## Note - Would it be more intuitive to move Surgery related items to Medical Doctor?
+## Also, individual surgical tools are also made available as it mightn't always viable to equip the surgical duffel bag
+## Getting the surgical duffel is cheaper than getting all the tools individually
+## However, Scalpel + Hemostat + Retractors + Cautery is only 4 points
+
+# Surgical Duffel
+- type: loadout
+  id: LoadoutMedicalRestrictedGearDuffelSurgeryFilled
+  category: JobsMedicalAUncategorized
+  cost: 5
+  items:
+    - ClothingBackpackDuffelSurgeryFilled
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Medical
+
+# Cautery
+- type: loadout
+  id: LoadoutMedicalRestrictedGearEquipmentCautery
+  category: JobsMedicalAUncategorized
+  cost: 1
+  items:
+    - Cautery
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Medical
+
+# Drill
+- type: loadout
+  id: LoadoutMedicalRestrictedGearEquipmentDrill
+  category: JobsMedicalAUncategorized
+  cost: 1
+  items:
+    - Drill
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Medical
+
+# Scalpel
+- type: loadout
+  id: LoadoutMedicalRestrictedGearEquipmentScalpel
+  category: JobsMedicalAUncategorized
+  cost: 1
+  items:
+    - Scalpel
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Medical
+
+# Retractor
+- type: loadout
+  id: LoadoutMedicalRestrictedGearEquipmentRetractor
+  category: JobsMedicalAUncategorized
+  cost: 1
+  items:
+    - Retractor
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Medical
+
+# Hemostat
+- type: loadout
+  id: LoadoutMedicalRestrictedGearEquipmentHemostat
+  category: JobsMedicalAUncategorized
+  cost: 1
+  items:
+    - Hemostat
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Medical
+
+# Bonesetter
+- type: loadout
+  id: LoadoutMedicalRestrictedGearEquipmentBonesetter
+  category: JobsMedicalAUncategorized
+  cost: 1
+  items:
+    - Bonesetter
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Medical
+
+# Bonegel
+- type: loadout
+  id: LoadoutMedicalRestrictedGearEquipmentBoneGel
+  category: JobsMedicalAUncategorized
+  cost: 1
+  items:
+    - BoneGel
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Medical
+
+# Metal Saw
+- type: loadout
+  id: LoadoutMedicalRestrictedGearEquipmentSaw
+  category: JobsMedicalAUncategorized
+  cost: 1
+  items:
+    - Saw
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Medical
+
+
+## Eyes
+# Medhud
+- type: loadout
+  id: LoadoutMedicalRestrictedGearEyesHudMedical
+  category: JobsMedicalAUncategorized
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutMedicalEyes
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Medical
+  items:
+    - ClothingEyesHudMedical
+
+# Eyepatch Medhud
+- type: loadout
+  id: LoadoutMedicalRestrictedGearEyepatchHudMedical
+  category: JobsMedicalAUncategorized
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutMedicalEyes
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Medical
+  items:
+    - ClothingEyesEyepatchHudMedical
+
+# Medhud Prescription
+- type: loadout
+  id: LoadoutMedicalRestrictedGearHudMedicalPrescription
+  category: JobsMedicalAUncategorized
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+        - Nearsighted
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutMedicalEyes
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Medical
+  items:
+    - ClothingEyesPrescriptionMedHud
+
+## Gloves
+# Nitrile
+- type: loadout
+  id: LoadoutMedicalRestrictedGearGlovesNitrile
+  category: JobsMedicalAUncategorized
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutMedicalGloves
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Medical
+  items:
+    - ClothingHandsGlovesNitrile
+
+# Latex
+- type: loadout
+  id: LoadoutMedicalRestrictedGearGlovesLatex
+  category: JobsMedicalAUncategorized
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutMedicalGloves
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Medical
+  items:
+    - ClothingHandsGlovesLatex
+
+## Stethoscope
+- type: loadout
+  id: LoadoutMedicalRestrictedGearNeckStethoscope
+  category: JobsMedicalAUncategorized
+  cost: 1
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Medical
+  items:
+    - ClothingNeckStethoscope
+
+
+### Chemist
+## Drugs
+# Kelotane
+- type: loadout
+  id: LoadoutMedicalRestrictedGearPillCanisterKelotane
+  category: JobsMedicalChemist
+  cost: 2
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChemistEquipment
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Chemist
+  items:
+    - PillCanisterKelotane
+
+# Tricordrazine
+- type: loadout
+  id: LoadoutMedicalRestrictedGearPillCanisterTricordrazine
+  category: JobsMedicalChemist
+  cost: 1
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChemistEquipment
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Chemist
+  items:
+    - PillCanisterTricordrazine
+
+# Hyronalin
+- type: loadout
+  id: LoadoutMedicalRestrictedGearPillCanisterHyronalin
+  category: JobsMedicalChemist
+  cost: 2
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChemistEquipment
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Chemist
+  items:
+    - PillCanisterHyronalin
+
+# Bicaridine
+- type: loadout
+  id: LoadoutMedicalRestrictedGearPillCanisterBicaridine
+  category: JobsMedicalChemist
+  cost: 2
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChemistEquipment
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Chemist
+  items:
+    - PillCanisterBicaridine
+
+# Dermaline
+- type: loadout
+  id: LoadoutMedicalRestrictedGearPillCanisterDermaline
+  category: JobsMedicalChemist
+  cost: 2
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChemistEquipment
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Chemist
+  items:
+    - PillCanisterDermaline
+
+# Dylovene
+- type: loadout
+  id: LoadoutMedicalRestrictedGearPillCanisterDylovene
+  category: JobsMedicalChemist
+  cost: 2
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChemistEquipment
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Chemist
+  items:
+    - PillCanisterDylovene
+
+# Dexalin
+- type: loadout
+  id: LoadoutMedicalRestrictedGearPillCanisterDexalin
+  category: JobsMedicalChemist
+  cost: 1
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChemistEquipment
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Chemist
+  items:
+    - PillCanisterDexalin
+
+# LSD
+- type: loadout
+  id: LoadoutMedicalRestrictedGearPillCanisterSpaceDrugs
+  category: JobsMedicalChemist
+  cost: 1
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChemistEquipment
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Chemist
+  items:
+    - PillCanisterSpaceDrugs
+
+## Chemical Analysis Goggles
+- type: loadout
+  id: LoadoutMedicalRestrictedGearEyesGlassesChemical
+  category: JobsMedicalChemist
+  cost: 4
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Chemist
+  items:
+    - ClothingEyesGlassesChemical
+
+### Medical Doctor
+- type: loadout
+  id: LoadoutMedicalRestrictedGearBeltMedicalFilled
+  category: JobsMedicalMedicalDoctor
+  cost: 4
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - MedicalDoctor
+  items:
+    - ClothingBeltMedicalFilled
+
+
+### Paramedic
+- type: loadout
+  id: LoadoutMedicalRestrictedGearPortafib
+  category: JobsMedicalParamedic
+  cost: 3
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Paramedic
+  items:
+    - Portafib

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/traitRestrictedGear.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/traitRestrictedGear.yml
@@ -156,7 +156,7 @@
 - type: loadout
   id: LoadoutMedicalRestrictedGearEyesHudMedical
   category: JobsMedicalAUncategorized
-  cost: 2
+  cost: 1
   exclusive: true
   requirements:
     - !type:CharacterTraitRequirement
@@ -175,7 +175,7 @@
 - type: loadout
   id: LoadoutMedicalRestrictedGearEyepatchHudMedical
   category: JobsMedicalAUncategorized
-  cost: 2
+  cost: 1
   exclusive: true
   requirements:
     - !type:CharacterTraitRequirement
@@ -194,7 +194,7 @@
 - type: loadout
   id: LoadoutMedicalRestrictedGearHudMedicalPrescription
   category: JobsMedicalAUncategorized
-  cost: 2
+  cost: 1
   exclusive: true
   requirements:
     - !type:CharacterTraitRequirement
@@ -432,7 +432,7 @@
 - type: loadout
   id: LoadoutMedicalRestrictedGearBeltMedicalFilled
   category: JobsMedicalMedicalDoctor
-  cost: 4
+  cost: 3
   requirements:
     - !type:CharacterTraitRequirement
       traits:

--- a/Resources/Prototypes/Loadouts/Jobs/Security/traitRestrictedGear.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/traitRestrictedGear.yml
@@ -1,0 +1,90 @@
+### All Security
+## Holster
+- type: loadout
+  id: LoadoutSecurityRestrictedGearBeltHolster
+  category: JobsSecurityAUncategorized
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Security
+  items:
+    - ClothingBeltHolster
+
+## Outer
+- type: loadout
+  id: LoadoutSecurityRestrictedGearOuterArmorPlateCarrier
+  category: JobsSecurityAUncategorized
+  cost: 7
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSecurityOuter
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Security
+  items:
+    - ClothingOuterArmorPlateCarrier
+
+- type: loadout
+  id: LoadoutSecurityRestrictedGearOuterArmorDuraVest
+  category: JobsSecurityAUncategorized
+  cost: 7
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSecurityOuter
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Security
+  items:
+    - ClothingOuterArmorDuraVest
+
+- type: loadout
+  id: LoadoutSecurityRestrictedGearOuterArmorBasic
+  category: JobsSecurityAUncategorized
+  cost: 7
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSecurityOuter
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Security
+  items:
+    - ClothingOuterArmorBasic
+
+- type: loadout
+  id: LoadoutSecurityRestrictedGearOuterArmorSlim
+  category: JobsSecurityAUncategorized
+  cost: 7
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - RestrictedGear
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSecurityOuter
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Security
+  items:
+    - ClothingOuterArmorBasicSlim

--- a/Resources/Prototypes/Loadouts/Jobs/Security/traitRestrictedGear.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/traitRestrictedGear.yml
@@ -20,7 +20,7 @@
 - type: loadout
   id: LoadoutSecurityRestrictedGearOuterArmorPlateCarrier
   category: JobsSecurityAUncategorized
-  cost: 7
+  cost: 5
   exclusive: true
   requirements:
     - !type:CharacterTraitRequirement
@@ -38,7 +38,7 @@
 - type: loadout
   id: LoadoutSecurityRestrictedGearOuterArmorDuraVest
   category: JobsSecurityAUncategorized
-  cost: 7
+  cost: 5
   exclusive: true
   requirements:
     - !type:CharacterTraitRequirement
@@ -56,7 +56,7 @@
 - type: loadout
   id: LoadoutSecurityRestrictedGearOuterArmorBasic
   category: JobsSecurityAUncategorized
-  cost: 7
+  cost: 5
   exclusive: true
   requirements:
     - !type:CharacterTraitRequirement
@@ -74,7 +74,7 @@
 - type: loadout
   id: LoadoutSecurityRestrictedGearOuterArmorSlim
   category: JobsSecurityAUncategorized
-  cost: 7
+  cost: 5
   exclusive: true
   requirements:
     - !type:CharacterTraitRequirement

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -500,7 +500,7 @@
             - NaturalWeaponRemoval
             - MartialArtist
   functions:
-    - !type:TraitModifyUned
+    - !type:TraitModifyUnarmed
       flatDamageIncrease:
         types:
           Blunt: 2

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -395,7 +395,6 @@
             types:
               Blunt: 0
 
-
 - type: trait
   id: Claws
   category: Physical
@@ -454,7 +453,7 @@
         - Talons
         - Claws
   functions:
-    - !type:TraitModifyUnarmed
+    - !type:TraitModifyUned
       soundHit:
         collection: Punch
       animation: WeaponArcFist
@@ -477,25 +476,11 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    #- !type:CharacterSpeciesRequirement
-    #  species:
-    #    - Human # Entirely arbitrary, I've decided I want a trait unique to humans. Since they don't normally get anything exciting.
-                # When we get the Character Records system in, I also want to make this require certain Backgrounds.
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
         - Claws
         - Talons
-    - !type:CharacterLogicOrRequirement
-      requirements:
-        - !type:CharacterTraitRequirement
-          traits:
-            - MartialArtist
-        - !type:CharacterJobRequirement
-          jobs:
-            - Boxer
-            - MartialArtist
-            - Gladiator
     - !type:CharacterLogicOrRequirement
       requirements:
         - !type:CharacterSpeciesRequirement
@@ -515,7 +500,7 @@
             - NaturalWeaponRemoval
             - MartialArtist
   functions:
-    - !type:TraitModifyUnarmed
+    - !type:TraitModifyUned
       flatDamageIncrease:
         types:
           Blunt: 2
@@ -547,7 +532,6 @@
     - !type:TraitAddTag
       tags:
         - SpiderCraft
-
 
 - type: trait
   id: BionicArm
@@ -657,42 +641,33 @@
       components:
         - type: Flashable # Effectively, removes any flash-vulnerability species traits.
 
-
-- type: trait
-  id: FlareShielding
-  category: Physical
-  points: -4
-  requirements:
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Security
-    - !type:CharacterTraitRequirement
-      traits:
-        - CyberEyes
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: FlashImmunity
-        - type: EyeProtection
-
-
 - type: trait
   id: CyberEyesSecurity
   category: Physical
-  points: -1
+  points: -2
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Security
-        - Command
-        - Dignitary
-    - !type:CharacterTraitRequirement
-      traits:
-        - CyberEyes
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterDepartmentRequirement
+          departments:
+            - Security
+            - Dignitary
+            - Command
+        - !type:CharacterTraitRequirement
+          traits:
+            - RestrictedGear
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterTraitRequirement
+          traits:
+            - CyberEyes
+        - !type:CharacterSpeciesRequirement
+          species:
+            - IPC
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
@@ -703,6 +678,8 @@
         - type: ShowJobIcons
         - type: ShowMindShieldIcons
         - type: ShowCriminalRecordIcons
+        - type: FlashImmunity
+        - type: EyeProtection
 
 - type: trait
   id: CyberEyesMedical
@@ -713,13 +690,17 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterTraitRequirement
-      traits:
-        - CyberEyes
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterTraitRequirement
+          traits:
+            - CyberEyes
+        - !type:CharacterSpeciesRequirement
+          species:
+            - IPC
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
-        - CyberEyesDiagnostic
         - CyberEyesOmni
   functions:
     - !type:TraitAddComponent
@@ -741,13 +722,17 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterTraitRequirement
-      traits:
-        - CyberEyes
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterTraitRequirement
+          traits:
+            - CyberEyes
+        - !type:CharacterSpeciesRequirement
+          species:
+            - IPC
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
-        - CyberEyesMedical
         - CyberEyesOmni
   functions:
     - !type:TraitAddComponent
@@ -767,15 +752,24 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Security
-        - Dignitary
-        - Command
-        - Dignitary
-    - !type:CharacterTraitRequirement
-      traits:
-        - CyberEyes
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterDepartmentRequirement
+          departments:
+            - Security
+            - Dignitary
+            - Command
+        - !type:CharacterTraitRequirement
+          traits:
+            - RestrictedGear
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterTraitRequirement
+          traits:
+            - CyberEyes
+        - !type:CharacterSpeciesRequirement
+          species:
+            - IPC
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
@@ -787,6 +781,7 @@
       components:
         - type: SolutionScanner
         - type: EyeProtection
+        - type: FlashImmunity
         - type: ShowJobIcons
         - type: ShowMindShieldIcons
         - type: ShowCriminalRecordIcons
@@ -856,9 +851,14 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterTraitRequirement
-      traits:
-        - CyberEyes
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterTraitRequirement
+          traits:
+            - CyberEyes
+        - !type:CharacterSpeciesRequirement
+          species:
+            - IPC
   functions:
     - !type:TraitAddComponent
       components:
@@ -873,9 +873,14 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterTraitRequirement
-      traits:
-        - CyberEyes
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterTraitRequirement
+          traits:
+            - CyberEyes
+        - !type:CharacterSpeciesRequirement
+          species:
+            - IPC
   functions:
     - !type:TraitAddComponent
       components:
@@ -948,198 +953,6 @@
       partSymmetry: Right
       protoId: SpeedRightLeg
       slotId: "right leg"
-
-- type: trait
-  id: FlareShieldingModule
-  category: Physical
-  points: -4
-  requirements:
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Security
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
-    - !type:CharacterTraitRequirement
-      inverted: true
-      traits:
-        - Photophobia
-        - Blindness
-        - Nearsighted
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: FlashImmunity
-        - type: EyeProtection
-
-- type: trait
-  id: SecurityEyesModule
-  category: Physical
-  points: -1
-  requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Security
-        - Command
-        - Dignitary
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
-    - !type:CharacterTraitRequirement
-      inverted: true
-      traits:
-        - OmniEyesModule
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: ShowJobIcons
-        - type: ShowMindShieldIcons
-        - type: ShowCriminalRecordIcons
-
-- type: trait
-  id: MedicalEyesModule
-  category: Physical
-  points: -2
-  requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
-    - !type:CharacterTraitRequirement
-      inverted: true
-      traits:
-        - DiagnosticEyesModule
-        - OmniEyesModule
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: SolutionScanner
-        - type: ShowHealthBars
-          damageContainers:
-          - Biological
-        - type: ShowHealthIcons
-          damageContainers:
-          - Biological
-
-- type: trait
-  id: DiagnosticEyesModule
-  category: Physical
-  points: -2
-  requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
-    - !type:CharacterTraitRequirement
-      inverted: true
-      traits:
-        - MedicalEyesModule
-        - OmniEyesModule
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: EyeProtection
-        - type: ShowHealthBars
-          damageContainers:
-          - Inorganic
-          - Silicon
-
-- type: trait
-  id: OmniEyesModule
-  category: Physical
-  points: -3
-  requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Security
-        - Dignitary
-        - Command
-        - Dignitary
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
-    - !type:CharacterTraitRequirement
-      inverted: true
-      traits:
-        - Photophobia
-        - Blindness
-        - Nearsighted
-        - MedicalEyesModule
-        - DiagnosticEyesModule
-        - SecurityEyesModule
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: SolutionScanner
-        - type: EyeProtection
-        - type: ShowJobIcons
-        - type: ShowMindShieldIcons
-        - type: ShowCriminalRecordIcons
-        - type: ShowHealthIcons
-          damageContainers:
-          - Biological
-        - type: ShowHealthBars
-          damageContainers:
-          - Biological
-          - Inorganic
-          - Silicon
-
-- type: trait
-  id: LightAmplificationModule
-  category: Physical
-  points: -4
-  requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: NightVision
-
-- type: trait
-  id: ThermographicVisionModule
-  category: Physical
-  points: -4
-  requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: ThermalVision
-          pulseTime: 2
-          toggleAction: PulseThermalVision
-    - !type:TraitPushDescription
-      descriptionExtensions:
-        - description: examine-thermal-vision-message
-          fontSize: 12
-          requireDetailRange: true
 
 # - type: trait
 #   id: Bulky
@@ -1251,3 +1064,13 @@
           - Pill
           - Crayon
           - Paper
+
+- type: trait
+  id: RestrictedGear
+  category: Physical
+  points: -5
+  requirements:
+  - !type:CharacterJobRequirement
+    inverted: true
+    jobs:
+      - Prisoner # Smuggling for prisoners = immediate jailbreak.

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -453,7 +453,7 @@
         - Talons
         - Claws
   functions:
-    - !type:TraitModifyUned
+    - !type:TraitModifyUnarmed
       soundHit:
         collection: Punch
       animation: WeaponArcFist


### PR DESCRIPTION
# Description

This PR adds the Restricted Equipment Trait https://github.com/Simple-Station/Einstein-Engines/pull/1317 with minor tweaks and additions (numbers might get adjusted at some point if it's problematic), and also cleans up the IPC module traits by simply adding an OR Logic statement to the normal traits, which just means you can take it if you have Cybereyes Base OR are an IPC.

# Changelog

:cl:
- add: Restricted Equipment Trait
- tweak: Cyber-Eyes Modules have an OR statement so IPCs can take those
- tweak: Flare Protection has simply been moved to the Sechud Trait (and Omnihud)
- tweak: Striking Calluses doesn't have a bajillion requirements
- remove: Removed IPC Eye Modules no more clutter
