### PR TITLE
[PORT] Glimmer Tier Calculation Fixed 

### DIFF
--- a/Content.Shared/Psionics/Glimmer/GlimmerSystem.cs
+++ b/Content.Shared/Psionics/Glimmer/GlimmerSystem.cs
@@ -88,11 +88,11 @@ public sealed class GlimmerSystem : EntitySystem
 
         return glimmer switch
         {
-            <= 49 => GlimmerTier.Minimal,
-            >= 50 and <= 399 => GlimmerTier.Low,
-            >= 400 and <= 599 => GlimmerTier.Moderate,
-            >= 600 and <= 699 => GlimmerTier.High,
-            >= 700 and <= 899 => GlimmerTier.Dangerous,
+            < 50 => GlimmerTier.Minimal,
+            < 400 => GlimmerTier.Low,
+            < 600 => GlimmerTier.Moderate,
+            < 700 => GlimmerTier.High,
+            < 900 => GlimmerTier.Dangerous,
             _ => GlimmerTier.Critical,
         };
     }


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description


Original fix made by CamDot (Den PR#546). The following is her description. 

> Glimmer tier was previously defined by:
> <= 49 => GlimmerTier.Minimal,
> >= 50 and <= 399 => GlimmerTier.Low,
> >= 400 and <= 599 => GlimmerTier.Moderate,
> >= 600 and <= 699 => GlimmerTier.High,
> >= 700 and <= 899 => GlimmerTier.Dangerous,
> _ => GlimmerTier.Critical,
> 
> There are gaps between each tier.
> .I.e 49.5, 399.5, 599.5 etc would result in critical tier. And then, we roll the dice to see if we explode!
> 
> Given we are an inclusive community, I have updated the calculations to also be inclusive.
> 
> Good fun. Great meme. Now fixed.
> 
---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Implemented CamDot's glimmer probe fix 
