### PR TITLE
Changed minimum playercounts for Ninja, Normal Xenos, Clown Spiders, …

### DIFF
--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -178,7 +178,7 @@ public sealed partial class CCVars
     ///     Time in minutes after round start to auto-call the shuttle. Set to zero to disable.
     /// </summary>
     public static readonly CVarDef<int> EmergencyShuttleAutoCallTime =
-        CVarDef.Create("shuttle.auto_call_time", 180, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.auto_call_time", 0, CVar.SERVERONLY);
 
     /// <summary>
     ///     Time in minutes after the round was extended (by recalling the shuttle) to call

--- a/Resources/Prototypes/DeltaV/GameRules/events.yml
+++ b/Resources/Prototypes/DeltaV/GameRules/events.yml
@@ -7,7 +7,7 @@
     startAnnouncement: true
     earliestStart: 20
     reoccurrenceDelay: 12
-    minimumPlayers: 15
+    minimumPlayers: 10
     weight: 6 # Really weak compared to other critters
     duration: 60
   - type: VentCrittersRule
@@ -78,7 +78,7 @@
   components:
   - type: StationEvent
     weight: 7.5
-    minimumPlayers: 10
+    minimumPlayers: 5
     maxOccurrences: 1
     duration: 1
   - type: PirateRadioSpawnRule

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -148,7 +148,7 @@
   - type: StationEvent
     weight: 6
     duration: 1
-    earliestStart: 90 # Floof
+    earliestStart: 5 # Floof
     reoccurrenceDelay: 60 # Floof
     minimumPlayers: 30 # Floof
   - type: SpaceSpawnRule
@@ -197,7 +197,7 @@
     weight: 7.5
     duration: 1
     earliestStart: 45
-    minimumPlayers: 20
+    minimumPlayers: 5
   - type: RandomSpawnRule
     prototype: MobRevenant
 
@@ -246,7 +246,7 @@
   - type: StationEvent
     earliestStart: 30
     weight: 7.5
-    minimumPlayers: 20 # Floof
+    minimumPlayers: 5 # Floof
     startAnnouncement: true
     endAnnouncement: true
     duration: null #ending is handled by MeteorSwarmRule
@@ -433,7 +433,7 @@
     startAnnouncement: true
     startDelay: 10
     earliestStart: 20
-    minimumPlayers: 15
+    minimumPlayers: 5
     weight: 3
     duration: 60
   - type: VentCrittersRule
@@ -454,7 +454,7 @@
     startAnnouncement: true
     startDelay: 10
     earliestStart: 20
-    minimumPlayers: 15
+    minimumPlayers: 5
     weight: 3
     duration: 60
   - type: VentCrittersRule
@@ -471,7 +471,7 @@
     startAnnouncement: false
     startDelay: 10
     earliestStart: 20
-    minimumPlayers: 20
+    minimumPlayers: 5
     weight: 1.5
     duration: 60
   - type: VentCrittersRule
@@ -590,8 +590,8 @@
   - type: StationEvent
     earliestStart: 25
     weight: 8
-    minimumPlayers: 15
-    reoccurrenceDelay: 30
+    minimumPlayers: 1
+    reoccurrenceDelay: 1
     startAnnouncement: false
 # - type: AlertLevelInterceptionRule - Disable setting to blue with sleeper agents. Uncomment to enable.
   - type: AntagSelection
@@ -599,8 +599,8 @@
     - prefRoles: [ TraitorSleeper ]
       fallbackRoles: [ Traitor ]
       min: 1
-      max: 2
-      playerRatio: 10
+      max: 99
+      playerRatio: 1
       blacklist:
         components:
         - AntagImmune
@@ -654,7 +654,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: StationEvent
-      earliestStart: 20 # Floof
+      earliestStart: 5 # Floof
       minimumPlayers: 20
       maxOccurrences: 1 # this event has diminishing returns on interesting-ness, so we cap it
       weight: 5

--- a/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
+++ b/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
@@ -20,7 +20,7 @@
   - type: StationEvent
     weight: 7
     reoccurrenceDelay: 5
-    minimumPlayers: 15
+    minimumPlayers: 5
     earliestStart: 25
   - type: MidRoundAntagRule
 


### PR DESCRIPTION
…Revenants, and meteor Swarms.

Disabled Autorecall.

Changed Traitor and Sleeper agent weights so players can it as often as possible.

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

Certain Antags and critters are now able to spawn when it's over five players

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->


- [x] Changed Weights for Traitors and Sleeper Agents so players are usually guaranteed to get the role when they opt into it 
- [x] Certain Antags and Critters can now spawn when there are over five players.
- [x] Disabled Auto Recall

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:

- tweak: Disabled Auto Recall
- tweak: Clown Spiders, Spiders, Ninjas, and Revenants, and Meteor Swarms can now occur if there are more than five players, Normal Xenos when there are more than ten.
- tweak: Traitor and Sleeper Agent Values changed to make it more likely for people to roll it if they opted into it.


