### PR TITLE
Zombies Minimum to 20 players, Only 1 Role

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -520,14 +520,14 @@
   components:
   - type: StationEvent
     earliestStart: 90
-    minimumPlayers: 40
+    minimumPlayers: 20
     weight: 1 # Zombies was happening basically every single survival round, so now it's super rare
     duration: 1
   - type: ZombieRule
   - type: AntagSelection
     definitions:
     - prefRoles: [ InitialInfected ]
-      max: 3
+      max: 1
       playerRatio: 10
       blacklist:
         components:


### PR DESCRIPTION

# Description
Lowers the players needed for zombies to spawn to 20 from 40 and makes it so only 1 Initial Infected spawns.

Zombies are a very difficult thing to balance, I recommend making a IC roleplay rule that if they are selected to be an initial infected that they cannot make Preparations to infect as many people as possible (Getting Armor or some such.)

Zombies can provide a fantastic avenue of roleplay for the medical staff of the station with the virology department.

Possible impacts on the station is having a potential high-threat for the station, though on rounds with 20+ people they likely have security online to combat the threat.

---

# TODO


- [x] Change numbers to specified



# Changelog


:cl:
- tweak: Lowered requirements for Zombies to spawn.

