### PR TITLE
Readds Friendly Xenos

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/xenopet.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xenopet.yml
@@ -1,389 +1,388 @@
-# - type: entity
-#   name: Friendly NT Rouny
-#   id: MobXenoNeutralRouny
-#   parent: MobXenoRounyNPC
-#   description: A friendly Rouny trained by Centcomm
-#   components:
-#   - type: NpcFactionMember
-#     factions:
-#     - PetsNT
-#   - type: LayingDown
-#   - type: Sprite
-#     drawdepth: Mobs
-#     sprite: Mobs/Aliens/FXS/rouny.rsi
-#     scale: 0.6, 0.6
-#   - type: PointLight
-#     radius: 2
-#     energy: 1
-#     color: "#B85E5E"
-#   - type: MovementAlwaysTouching
-#   - type: GhostRole
-#     name: ghost-role-information-friendlyxeno-name
-#     description: ghost-role-information-friendlyxeno-description
-#     rules: ghost-role-information-friendlyxeno-rules
-#   - type: GhostTakeoverAvailable
-#   - type: Inventory
-#     templateId: friendxeno
-#   - type: IdExaminable
-#   - type: InventorySlots
-#   - type: Stripping
-#   - type: Strippable
-#   - type: UserInterface
-#     interfaces:
-#       enum.StrippingUiKey.Key:
-#         type: StrippableBoundUserInterface
-#   - type: Grammar
-#     attributes:
-#       proper: true
-#       gender: male
-#   - type: Body
-#     prototype: Friendshaped
-#     requiredLegs: 1 # TODO: More than 1 leg
-#   - type: InteractionPopup
-#     successChance: 0.5
-#     interactSuccessString: petting-success-reptile
-#     interactFailureString: petting-failure-generic
-#     interactSuccessSpawn: EffectHearts
-#     interactSuccessSound:
-#       path: /Audio/Animals/lizard_happy.ogg
-#   - type: LanguageKnowledge
-#     speaks:
-#     - Xeno
-#     understands:
-#     - Xeno
-#     - TauCetiBasic
+ - type: entity
+   name: Friendly NT Rouny
+   id: MobXenoNeutralRouny
+   parent: MobXenoRounyNPC
+   description: A friendly Rouny trained by Centcomm
+   components:
+   - type: NpcFactionMember
+     factions:
+     - PetsNT
+   - type: LayingDown
+   - type: Sprite
+     drawdepth: Mobs
+     sprite: Mobs/Aliens/FXS/rouny.rsi
+     scale: 0.6, 0.6
+   - type: PointLight
+     radius: 2
+     energy: 1
+     color: "#B85E5E"
+   - type: MovementAlwaysTouching
+   - type: GhostRole
+     name: ghost-role-information-friendlyxeno-name
+     description: ghost-role-information-friendlyxeno-description
+     rules: ghost-role-information-friendlyxeno-rules
+   - type: GhostTakeoverAvailable
+   - type: Inventory
+     templateId: friendxeno
+   - type: IdExaminable
+   - type: InventorySlots
+   - type: Stripping
+   - type: Strippable
+   - type: UserInterface
+     interfaces:
+       enum.StrippingUiKey.Key:
+         type: StrippableBoundUserInterface
+   - type: Grammar
+     attributes:
+       proper: true
+       gender: male
+   - type: Body
+     prototype: Friendshaped
+     requiredLegs: 1 # TODO: More than 1 leg
+   - type: InteractionPopup
+     successChance: 0.5
+     interactSuccessString: petting-success-reptile
+     interactFailureString: petting-failure-generic
+     interactSuccessSpawn: EffectHearts
+     interactSuccessSound:
+       path: /Audio/Animals/lizard_happy.ogg
+   - type: LanguageKnowledge
+     speaks:
+     - Xeno
+     understands:
+     - Xeno
+     - TauCetiBasic
 
-# - type: entity
-#   name: Friendly NT Praetorian
-#   id: MobXenoNeutralPraetorian
-#   parent: MobXenoPraetorianNPC
-#   description: A friendly Praetorian programmed by centcomm
-#   components:
-#   - type: NpcFactionMember
-#     factions:
-#     - PetsNT
-#   - type: LayingDown
-#   - type: Sprite
-#     drawdepth: Mobs
-#     sprite: Mobs/Aliens/FXS/praetorian.rsi
-#     scale: 0.8, 0.8
-#   - type: PointLight
-#     radius: 2
-#     energy: 1
-#     color: "#62B85E"
-#   - type: GhostRole
-#     name: ghost-role-information-friendlyxeno-name
-#     description: ghost-role-information-friendlyxeno-description
-#     rules: ghost-role-information-friendlyxeno-rules
-#   - type: GhostTakeoverAvailable
-#   - type: Inventory
-#     templateId: friendxeno
-#   - type: IdExaminable
-#   - type: InventorySlots
-#   - type: Stripping
-#   - type: Strippable
-#   - type: UserInterface
-#     interfaces:
-#       enum.StrippingUiKey.Key:
-#         type: StrippableBoundUserInterface
-#   - type: Grammar
-#     attributes:
-#       proper: true
-#       gender: male
-#   - type: Body
-#     prototype: Friendshaped
-#     requiredLegs: 1 # TODO: More than 1 leg
-#   - type: InteractionPopup
-#     successChance: 0.5
-#     interactSuccessString: petting-success-reptile
-#     interactFailureString: petting-failure-generic
-#     interactSuccessSpawn: EffectHearts
-#     interactSuccessSound:
-#       path: /Audio/Animals/lizard_happy.ogg
-#   - type: LanguageKnowledge
-#     speaks:
-#     - Xeno
-#     understands:
-#     - Xeno
-#     - TauCetiBasic
+ - type: entity
+   name: Friendly NT Praetorian
+   id: MobXenoNeutralPraetorian
+   parent: MobXenoPraetorianNPC
+   description: A friendly Praetorian programmed by centcomm
+   components:
+   - type: NpcFactionMember
+     factions:
+     - PetsNT
+   - type: LayingDown
+   - type: Sprite
+     drawdepth: Mobs
+     sprite: Mobs/Aliens/FXS/praetorian.rsi
+     scale: 0.8, 0.8
+   - type: PointLight
+     radius: 2
+     energy: 1
+     color: "#62B85E"
+   - type: GhostRole
+     name: ghost-role-information-friendlyxeno-name
+     description: ghost-role-information-friendlyxeno-description
+     rules: ghost-role-information-friendlyxeno-rules
+   - type: GhostTakeoverAvailable
+   - type: Inventory
+     templateId: friendxeno
+   - type: IdExaminable
+   - type: InventorySlots
+   - type: Stripping
+   - type: Strippable
+   - type: UserInterface
+     interfaces:
+       enum.StrippingUiKey.Key:
+         type: StrippableBoundUserInterface
+   - type: Grammar
+     attributes:
+       proper: true
+       gender: male
+   - type: Body
+     prototype: Friendshaped
+     requiredLegs: 1 # TODO: More than 1 leg
+   - type: InteractionPopup
+     successChance: 0.5
+     interactSuccessString: petting-success-reptile
+     interactFailureString: petting-failure-generic
+     interactSuccessSpawn: EffectHearts
+     interactSuccessSound:
+       path: /Audio/Animals/lizard_happy.ogg
+   - type: LanguageKnowledge
+     speaks:
+     - Xeno
+     understands:
+     - Xeno
+     - TauCetiBasic
 
-# - type: entity
-#   name: Friendly NT Drone
-#   id: MobXenoNeutralDrone
-#   parent: MobXenoDroneNPC
-#   description: A friendly drone programmed by centcomm
-#   components:
-#   - type: NpcFactionMember
-#     factions:
-#     - PetsNT
-#   - type: LayingDown
-#   - type: Sprite
-#     drawdepth: Mobs
-#     sprite: Mobs/Aliens/FXS/drone.rsi
-#     scale: 0.8, 0.8
-#   - type: PointLight
-#     radius: 2
-#     energy: 1
-#     color: "#8B5EB8"
-#   - type: GhostRole
-#     name: ghost-role-information-friendlyxeno-name
-#     description: ghost-role-information-friendlyxeno-description
-#     rules: ghost-role-information-friendlyxeno-rules
-#   - type: GhostTakeoverAvailable
-#   - type: Inventory
-#     templateId: friendxeno
-#   - type: IdExaminable
-#   - type: InventorySlots
-#   - type: Stripping
-#   - type: Strippable
-#   - type: UserInterface
-#     interfaces:
-#       enum.StrippingUiKey.Key:
-#         type: StrippableBoundUserInterface
-#   - type: Grammar
-#     attributes:
-#       proper: true
-#       gender: male
-#   - type: Body
-#     prototype: Friendshaped
-#     requiredLegs: 1 # TODO: More than 1 leg
-#   - type: InteractionPopup
-#     successChance: 0.5
-#     interactSuccessString: petting-success-reptile
-#     interactFailureString: petting-failure-generic
-#     interactSuccessSpawn: EffectHearts
-#     interactSuccessSound:
-#       path: /Audio/Animals/lizard_happy.ogg
-#   - type: LanguageKnowledge
-#     speaks:
-#     - Xeno
-#     understands:
-#     - Xeno
-#     - TauCetiBasic
+ - type: entity
+   name: Friendly NT Drone
+   id: MobXenoNeutralDrone
+   parent: MobXenoDroneNPC
+   description: A friendly drone programmed by centcomm
+   components:
+   - type: NpcFactionMember
+     factions:
+     - PetsNT
+   - type: LayingDown
+   - type: Sprite
+     drawdepth: Mobs
+     sprite: Mobs/Aliens/FXS/drone.rsi
+     scale: 0.8, 0.8
+   - type: PointLight
+     radius: 2
+     energy: 1
+     color: "#8B5EB8"
+   - type: GhostRole
+     name: ghost-role-information-friendlyxeno-name
+     description: ghost-role-information-friendlyxeno-description
+     rules: ghost-role-information-friendlyxeno-rules
+   - type: GhostTakeoverAvailable
+   - type: Inventory
+     templateId: friendxeno
+   - type: IdExaminable
+   - type: InventorySlots
+   - type: Stripping
+   - type: Strippable
+   - type: UserInterface
+     interfaces:
+       enum.StrippingUiKey.Key:
+         type: StrippableBoundUserInterface
+   - type: Grammar
+     attributes:
+       proper: true
+       gender: male
+   - type: Body
+     prototype: Friendshaped
+     requiredLegs: 1 # TODO: More than 1 leg
+   - type: InteractionPopup
+     successChance: 0.5
+     interactSuccessString: petting-success-reptile
+     interactFailureString: petting-failure-generic
+     interactSuccessSpawn: EffectHearts
+     interactSuccessSound:
+       path: /Audio/Animals/lizard_happy.ogg
+   - type: LanguageKnowledge
+     speaks:
+     - Xeno
+     understands:
+     - Xeno
+     - TauCetiBasic
 
-# - type: entity
-#   name: Friendly NT Ravager
-#   id: MobXenoNeutralRavager
-#   parent: MobXenoRavagerNPC
-#   description: A friendly ravager programmed by centcomm
-#   components:
-#   - type: NpcFactionMember
-#     factions:
-#     - PetsNT
-#   - type: LayingDown
-#   - type: Sprite
-#     drawdepth: Mobs
-#     sprite: Mobs/Aliens/FXS/ravager.rsi
-#     scale: 0.7, 0.7
-#   - type: PointLight
-#     radius: 2
-#     energy: 1
-#     color: "#E3954D"
-#   - type: GhostRole
-#     name: ghost-role-information-friendlyxeno-name
-#     description: ghost-role-information-friendlyxeno-description
-#     rules: ghost-role-information-friendlyxeno-rules
-#   - type: GhostTakeoverAvailable
-#   - type: Inventory
-#     templateId: friendxeno
-#   - type: IdExaminable
-#   - type: InventorySlots
-#   - type: Stripping
-#   - type: Strippable
-#   - type: UserInterface
-#     interfaces:
-#       enum.StrippingUiKey.Key:
-#         type: StrippableBoundUserInterface
-#   - type: Grammar
-#     attributes:
-#       proper: true
-#       gender: male
-#   - type: Body
-#     prototype: Friendshaped
-#     requiredLegs: 1 # TODO: More than 1 leg
-#   - type: InteractionPopup
-#     successChance: 0.5
-#     interactSuccessString: petting-success-reptile
-#     interactFailureString: petting-failure-generic
-#     interactSuccessSpawn: EffectHearts
-#     interactSuccessSound:
-#       path: /Audio/Animals/lizard_happy.ogg
-#   - type: LanguageKnowledge
-#     speaks:
-#     - Xeno
-#     understands:
-#     - Xeno
-#     - TauCetiBasic
+ - type: entity
+   name: Friendly NT Ravager
+   id: MobXenoNeutralRavager
+   parent: MobXenoRavagerNPC
+   description: A friendly ravager programmed by centcomm
+   components:
+   - type: NpcFactionMember
+     factions:
+     - PetsNT
+   - type: LayingDown
+   - type: Sprite
+     drawdepth: Mobs
+     sprite: Mobs/Aliens/FXS/ravager.rsi
+     scale: 0.7, 0.7
+   - type: PointLight
+     radius: 2
+     energy: 1
+     color: "#E3954D"
+   - type: GhostRole
+     name: ghost-role-information-friendlyxeno-name
+     description: ghost-role-information-friendlyxeno-description
+     rules: ghost-role-information-friendlyxeno-rules
+   - type: GhostTakeoverAvailable
+   - type: Inventory
+     templateId: friendxeno
+   - type: IdExaminable
+   - type: InventorySlots
+   - type: Stripping
+   - type: Strippable
+   - type: UserInterface
+     interfaces:
+       enum.StrippingUiKey.Key:
+         type: StrippableBoundUserInterface
+   - type: Grammar
+     attributes:
+       proper: true
+       gender: male
+   - type: Body
+     prototype: Friendshaped
+     requiredLegs: 1 # TODO: More than 1 leg
+   - type: InteractionPopup
+     successChance: 0.5
+     interactSuccessString: petting-success-reptile
+     interactFailureString: petting-failure-generic
+     interactSuccessSpawn: EffectHearts
+     interactSuccessSound:
+       path: /Audio/Animals/lizard_happy.ogg
+   - type: LanguageKnowledge
+     speaks:
+     - Xeno
+     understands:
+     - Xeno
+     - TauCetiBasic
 
-# - type: entity
-#   name: Friendly CC Rouny
-#   id: MobXenoCCNeutralRouny
-#   parent: MobXenoNeutralRouny
-#   description: A friendly rouny programmed by centcomm
-#   components:
-#   - type: Sprite
-#     drawdepth: Mobs
-#     sprite: Mobs/Aliens/FXS/ccrouny.rsi
-#     scale: 0.7, 0.7
+ - type: entity
+   name: Friendly CC Rouny
+   id: MobXenoCCNeutralRouny
+   parent: MobXenoNeutralRouny
+   description: A friendly rouny programmed by centcomm
+   components:
+   - type: Sprite
+     drawdepth: Mobs
+     sprite: Mobs/Aliens/FXS/ccrouny.rsi
+     scale: 0.7, 0.7
 
-# - type: entity
-#   name: Friendly CC Drone
-#   id: MobXenoCCNeutralDrone
-#   parent: MobXenoNeutralDrone
-#   description: A friendly drone programmed by centcomm
-#   components:
-#   - type: Sprite
-#     drawdepth: Mobs
-#     sprite: Mobs/Aliens/FXS/ccdrone.rsi
-#     scale: 0.7, 0.7
+ - type: entity
+   name: Friendly CC Drone
+   id: MobXenoCCNeutralDrone
+   parent: MobXenoNeutralDrone
+   description: A friendly drone programmed by centcomm
+   components:
+   - type: Sprite
+     drawdepth: Mobs
+     sprite: Mobs/Aliens/FXS/ccdrone.rsi
+     scale: 0.7, 0.7
 
-# - type: entity
-#   name: Friendly CC Praetorian
-#   id: MobXenoCCNeutralPraetorian
-#   parent: MobXenoNeutralPraetorian
-#   description: A friendly Praetorian programmed by centcomm
-#   components:
-#   - type: Sprite
-#     drawdepth: Mobs
-#     sprite: Mobs/Aliens/FXS/ccpraetorian.rsi
-#     scale: 0.7, 0.7
+ - type: entity
+   name: Friendly CC Praetorian
+   id: MobXenoCCNeutralPraetorian
+   parent: MobXenoNeutralPraetorian
+   description: A friendly Praetorian programmed by centcomm
+   components:
+   - type: Sprite
+     drawdepth: Mobs
+     sprite: Mobs/Aliens/FXS/ccpraetorian.rsi
+     scale: 0.7, 0.7
 
-# - type: entity
-#   name: Friendly CC Ravager
-#   id: MobXenoCCNeutralRavager
-#   parent: MobXenoNeutralRavager
-#   description: A friendly ravager programmed by centcomm
-#   components:
-#   - type: Sprite
-#     drawdepth: Mobs
-#     sprite: Mobs/Aliens/FXS/ccravager.rsi
-#     scale: 0.7, 0.7
+ - type: entity
+   name: Friendly CC Ravager
+   id: MobXenoCCNeutralRavager
+   parent: MobXenoNeutralRavager
+   description: A friendly ravager programmed by centcomm
+   components:
+   - type: Sprite
+     drawdepth: Mobs
+     sprite: Mobs/Aliens/FXS/ccravager.rsi
+     scale: 0.7, 0.7
 
-# - type: inventoryTemplate
-#   id: friendxeno
-#   slots:
-#   - name: id
-#     slotTexture: id
-#     slotFlags: IDCARD
-#     slotGroup: SecondHotbar
-#     stripTime: 6
-#     uiWindowPos: 2,1
-#     strippingWindowPos: 2,4
-#     displayName: ID
-#   - name: head
-#     slotTexture: head
-#     slotFlags: HEAD
-#     uiWindowPos: 1,2
-#     strippingWindowPos: 0,0
-#     displayName: Head
-#   - name: mask
-#     slotTexture: mask
-#     slotFlags: MASK
-#     uiWindowPos: 0,1
-#     strippingWindowPos: 1,1
-#     displayName: Mask
+ - type: inventoryTemplate
+   id: friendxeno
+   slots:
+   - name: id
+     slotTexture: id
+     slotFlags: IDCARD
+     slotGroup: SecondHotbar
+     stripTime: 6
+     uiWindowPos: 2,1
+     strippingWindowPos: 2,4
+     displayName: ID
+   - name: head
+     slotTexture: head
+     slotFlags: HEAD
+     uiWindowPos: 1,2
+     strippingWindowPos: 0,0
+     displayName: Head
+   - name: mask
+     slotTexture: mask
+     slotFlags: MASK
+     uiWindowPos: 0,1
+     strippingWindowPos: 1,1
+     displayName: Mask
 
-# - type: entity
-#   name: Friend-Shaped
-#   parent: MobXenoNeutralRouny
-#   id: MobXenoFriendShaped
-#   description: A very clearly friend-shaped Xeno.
-#   components:
-#   - type: NpcFactionMember
-#     factions:
-#     - PetsNT
-#   - type: Tool
-#     speed: 6
-#     qualities:
-#       - Prying
-#   - type: Sprite
-#     drawdepth: Mobs
-#     sprite: Mobs/Aliens/FXS/rouny.rsi
-#     scale: 0.6, 0.6
+ - type: entity
+   name: Friend-Shaped
+   parent: MobXenoNeutralRouny
+   id: MobXenoFriendShaped
+   description: A very clearly friend-shaped Xeno.
+   components:
+   - type: NpcFactionMember
+     factions:
+     - PetsNT
+   - type: Tool
+     speed: 6
+     qualities:
+       - Prying
+   - type: Sprite
+     drawdepth: Mobs
+     sprite: Mobs/Aliens/FXS/rouny.rsi
+     scale: 0.6, 0.6
 
-# # Floofstation - commented out for reasons unknown
-# - type: entity
-#   name: Patriach
-#   parent: MobXenoNeutralPraetorian
-#   id: MobXenoPatriarch
-#   description: A not entirely clearly friend-shaped Xeno.
-#   components:
-#   - type: NpcFactionMember
-#     factions:
-#     - PetsNT
-#   - type: Tool
-#     speed: 6
-#     qualities:
-#       - Prying
-#   - type: Sprite
-#     drawdepth: Mobs
-#     sprite: Mobs/Animals/patriarch.rsi
-#     layers:
-#     - map: ["enum.DamageStateVisualLayers.Base"]
-#       state: patriarch
-#   - type: DamageStateVisuals
-#     states:
-#       Alive:
-#         Base: patriarch
-#       Critical:
-#         Base: patriarch_crit
-#       Dead:
-#         Base: patriarch_dead
+ - type: entity
+   name: Patriach
+   parent: MobXenoNeutralPraetorian
+   id: MobXenoPatriarch
+   description: A not entirely clearly friend-shaped Xeno.
+   components:
+   - type: NpcFactionMember
+     factions:
+     - PetsNT
+   - type: Tool
+     speed: 6
+     qualities:
+       - Prying
+   - type: Sprite
+     drawdepth: Mobs
+     sprite: Mobs/Animals/patriarch.rsi
+     layers:
+     - map: ["enum.DamageStateVisualLayers.Base"]
+       state: patriarch
+   - type: DamageStateVisuals
+     states:
+       Alive:
+         Base: patriarch
+       Critical:
+         Base: patriarch_crit
+       Dead:
+         Base: patriarch_dead
 
-# - type: entity
-#   name: FXE Subject 7355
-#   parent: MobXenoNeutralRavager
-#   id: MobXenoSubjectTess
-#   description: An extremely oddly coloured xeno, with glowing stripes. An odd mutation.
-#   components:
-#   - type: NpcFactionMember
-#     factions:
-#      - PetsNT
-#   - type: Tool
-#     speed: 6
-#     qualities:
-#       - Prying
-#   - type: Sprite
-#     drawdepth: Mobs
-#     sprite: Mobs/Animals/subject7355.rsi
-#     layers:
-#     - map: ["enum.DamageStateVisualLayers.Base"]
-#       state: subject7355
-#     - map: [ "enum.DamageStateVisualLayers.BaseUnshaded" ]
-#       state: glow
-#       shader: unshaded
-#   - type: PointLight
-#     radius: 2
-#     energy: 1
-#     color: "#639fff"
-#   - type: DamageStateVisuals
-#     states:
-#       Alive:
-#         Base: subject7355
-#       Critical:
-#         Base: subject7355_crit
-#       Dead:
-#         Base: subject7355_dead
-#   - type: Inventory
-#     templateId: friendxeno
-#   - type: IdExaminable
-#   - type: InventorySlots
-#   - type: Strippable
-#   - type: UserInterface
-#     interfaces:
-#       enum.StrippingUiKey.Key:
-#         type: StrippableBoundUserInterface
-#   - type: Grammar
-#     attributes:
-#       proper: true
-#       gender: male
-#   - type: InteractionPopup
-#     successChance: 0.5
-#     interactSuccessString: petting-success-reptile
-#     interactFailureString: petting-failure-generic
-#     interactSuccessSpawn: EffectHearts
-#     interactSuccessSound:
-#       path: /Audio/Animals/lizard_happy.ogg
+ - type: entity
+   name: FXE Subject 7355
+   parent: MobXenoNeutralRavager
+   id: MobXenoSubjectTess
+   description: An extremely oddly coloured xeno, with glowing stripes. An odd mutation.
+   components:
+   - type: NpcFactionMember
+     factions:
+      - PetsNT
+   - type: Tool
+     speed: 6
+     qualities:
+       - Prying
+   - type: Sprite
+     drawdepth: Mobs
+     sprite: Mobs/Animals/subject7355.rsi
+     layers:
+     - map: ["enum.DamageStateVisualLayers.Base"]
+       state: subject7355
+     - map: [ "enum.DamageStateVisualLayers.BaseUnshaded" ]
+       state: glow
+       shader: unshaded
+   - type: PointLight
+     radius: 2
+     energy: 1
+     color: "#639fff"
+   - type: DamageStateVisuals
+     states:
+       Alive:
+         Base: subject7355
+       Critical:
+         Base: subject7355_crit
+       Dead:
+         Base: subject7355_dead
+   - type: Inventory
+     templateId: friendxeno
+   - type: IdExaminable
+   - type: InventorySlots
+   - type: Strippable
+   - type: UserInterface
+     interfaces:
+       enum.StrippingUiKey.Key:
+         type: StrippableBoundUserInterface
+   - type: Grammar
+     attributes:
+       proper: true
+       gender: male
+   - type: InteractionPopup
+     successChance: 0.5
+     interactSuccessString: petting-success-reptile
+     interactFailureString: petting-failure-generic
+     interactSuccessSpawn: EffectHearts
+     interactSuccessSound:
+       path: /Audio/Animals/lizard_happy.ogg
 
 # - type: entity
 #   id: neutralXenoVents
@@ -562,20 +561,20 @@
 #     - id: MobLuminousEntity
 #       prob: 0.01
 
-# - type: entity
-#   name: Friendly Xeno spawner
-#   id: friendlyxenoSpawner
-#   parent: MarkerBase
-#   components:
-#     - type: Sprite
-#       layers:
-#         - state: green
-#         - sprite: Mobs/Aliens/Xenos/drone.rsi
-#           state: sleeping
-#     - type: RandomSpawner
-#       prototypes:
-#         - MobXenoNeutralRouny
-#         - MobXenoNeutralPraetorian
-#         - MobXenoNeutralDrone
-#         - MobXenoNeutralRavager
-#       chance: 1
+ - type: entity
+   name: Friendly Xeno spawner
+   id: friendlyxenoSpawner
+   parent: MarkerBase
+   components:
+     - type: Sprite
+       layers:
+         - state: green
+         - sprite: Mobs/Aliens/Xenos/drone.rsi
+           state: sleeping
+     - type: RandomSpawner
+       prototypes:
+         - MobXenoNeutralRouny
+         - MobXenoNeutralPraetorian
+         - MobXenoNeutralDrone
+         - MobXenoNeutralRavager
+       chance: 1


### PR DESCRIPTION
This Commit mostly reverts abce6ea885532aa4366542bf2db3f74a56915171 which disabled most of the things in xenopet.yml, This makes it so the Central Command reprogrammed Xenonids are BACK and can be used ingame.  This could lead to some very interesting non-standard characters. :heart:

# Description

In 2024, the codebase commented out the Friendly Xenos, there was no description given and infact; in the file it states that it was commented out for an unknown reason.
I don't think we should have critters and things that could potentially become characters under the basis of an unknown reason; not even a reported bug with it.

This change can be easily reverted, and is a simple change, but I do hope that this PR is considered ❤️ 

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Xenopets.yml mostly recomment-ed back in.
- [x] Tested in Dev Server (see Media)

---
<details><summary><h1>Media</h1></summary>
<p>

<img width="385" height="438" alt="Screenshot 2025-08-27 215803" src="https://github.com/user-attachments/assets/e92f0374-e953-4991-8df4-30746243d6f3" />
<img width="370" height="415" alt="Screenshot 2025-08-27 215707" src="https://github.com/user-attachments/assets/28547609-0830-4c33-b595-eb15f27baa4d" />
<img width="395" height="560" alt="Screenshot 2025-08-27 215605" src="https://github.com/user-attachments/assets/aad91485-a735-482d-a303-e073d6332680" />


</p>
</details>

---

# Changelog

:cl:
- add: Re-Added Friendly Xenonids, FXE

