### PR TITLE
Enable OOC by default

### DIFF
--- a/Content.Shared/CCVar/CCVars.Chat.Ooc.cs
+++ b/Content.Shared/CCVar/CCVars.Chat.Ooc.cs
@@ -20,7 +20,7 @@ public sealed partial class CCVars
     ///     Whether or not OOC chat should be enabled during a round.
     /// </summary>
     public static readonly CVarDef<bool> OocEnableDuringRound =
-        CVarDef.Create("ooc.enable_during_round", false, CVar.NOTIFY | CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("ooc.enable_during_round", true, CVar.NOTIFY | CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<bool> ShowOocPatronColor =
         CVarDef.Create("ooc.show_ooc_patron_color", true, CVar.ARCHIVE | CVar.REPLICATED | CVar.CLIENT);


### PR DESCRIPTION
Enable OOC on Foxtrot



# Description

<!--

Enables OOC by default


# Changelog

:cl: Nerb
- tweak: OOC is now enabled by default, meaning no admin intervention is required to enable it!